### PR TITLE
Update README.md with psutil dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,13 +60,13 @@ urbansprawl works with Python 2+3.
 
 - Python dependencies:
 ```sh
-osmnx scikit-learn
+osmnx scikit-learn psutil
 ```
 
 * Using anaconda:
 ```sh
 conda update -c conda-forge --all
-conda install -c conda-forge osmnx scikit-learn
+conda install -c conda-forge osmnx scikit-learn psutil
 ```
 
 ## Example: Urban sprawl


### PR DESCRIPTION
This PR aims at fixing a missing dependency, in order to make `sprawl_overview.ipynb` work (more precisely, the `compute_grid_accessibility` method).
Indeed this method calls a method from subprocess library, however the resulting value looks not valid.
The PR fixes issue #3 .